### PR TITLE
chore: remove unneeded CI secret

### DIFF
--- a/.github/workflows/get-aggregate-deals.yml
+++ b/.github/workflows/get-aggregate-deals.yml
@@ -25,6 +25,4 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Run job
-        env:
-          CF_API_TOKEN: ${{ secrets.CF_GATEWAY_TOKEN }}
         run: npm run get-aggregate-deals -w packages/tools ${{ github.event.inputs.piece }}


### PR DESCRIPTION
It's not set anywhere and according to https://github.com/w3s-project/w3filecoin-infra/actions/runs/8566805403, the CI is working fine. Let's just remove it.