### PR TITLE
feat: add oracle stat tool command

### DIFF
--- a/.github/workflows/stat-oracle.yml
+++ b/.github/workflows/stat-oracle.yml
@@ -1,0 +1,23 @@
+name: Stat Oracle
+
+on:
+  workflow_dispatch:
+
+jobs:
+  statOracle:
+    name: Stat Oracle
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['staging', 'production']
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - name: Run job
+        run: npm run stat-oracle -w packages/tools

--- a/.github/workflows/stat-oracle.yml
+++ b/.github/workflows/stat-oracle.yml
@@ -20,4 +20,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Run job
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: npm run stat-oracle -w packages/tools

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -44,3 +44,15 @@ bafkzcibcaapn... at 2024-05-28T07:12:45.567Z
 bafkzcibcaapb... at 2024-05-28T07:48:21.420Z
 bafkzcibcaapi... at 2024-05-28T08:23:59.203Z
 ```
+
+### Stat oracle content
+
+```sh
+$ npm run stat-oracle
+
+> @w3filecoin/tools@0.0.0 stat-oracle
+> node stat-oracle.js
+
+Oracle Last Modified:  2024-05-30T14:33:37.000Z
+Oracle Content Length:  35424899
+```

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "get-aggregate-deals": "node get-aggregate-deals.js",
-    "get-aggregates-pending-deals": "node get-aggregates-pending-deals.js"
+    "get-aggregates-pending-deals": "node get-aggregates-pending-deals.js",
+    "stat-oracle": "node stat-oracle.js"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/tools/stat-oracle.js
+++ b/packages/tools/stat-oracle.js
@@ -1,0 +1,31 @@
+import { HeadObjectCommand } from '@aws-sdk/client-s3'
+
+import { connectBucket } from '@w3filecoin/core/src/store/index.js'
+
+
+const AWS_REGION = 'us-west-2'
+const spadeOracleUrl = 'https://api.spade.storage/public/daghaus_active_replicas.json.zst'
+
+const bucketClient = connectBucket({
+  region: AWS_REGION
+})
+const putCmd = new HeadObjectCommand({
+  Bucket: 'prod-w3filecoin-deal-tracker-deal-archive-store-1',
+  Key: encodeURIComponent(spadeOracleUrl)
+})
+
+let res
+try {
+  res = await bucketClient.send(putCmd)
+} catch (/** @type {any} */ error) {
+  if (error?.$metadata.httpStatusCode !== 404) {
+    throw error
+  }
+}
+
+if (!res) {
+  console.log('Oracle file not found')
+} else {
+  console.log('Oracle Last Modified:', res.LastModified)
+  console.log('Oracle Content Length:', res.ContentLength)
+}


### PR DESCRIPTION
Adds stat command to tools and a github action to run on github UI. This enables us to see last time we got new information on Oracle from Spade. It is useful for incidents when we have delays in deals because their Chain crawler is stuck