### PR TITLE
feat: add buffer stat tool command

### DIFF
--- a/.github/workflows/stat-buffer.yml
+++ b/.github/workflows/stat-buffer.yml
@@ -25,4 +25,7 @@ jobs:
           cache: 'npm'
       - run: npm ci
       - name: Run job
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: npm run stat-buffer -w packages/tools ${{ github.event.inputs.buffer }}

--- a/.github/workflows/stat-buffer.yml
+++ b/.github/workflows/stat-buffer.yml
@@ -1,0 +1,28 @@
+name: Stat Buffer
+
+on:
+  workflow_dispatch:
+    inputs:
+      buffer:
+        required: true
+        description: CID of the Buffer
+        type: string
+
+jobs:
+  statBuffer:
+    name: Stat Buffer
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        env: ['staging', 'production']
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          registry-url: 'https://registry.npmjs.org'
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - name: Run job
+        run: npm run stat-buffer -w packages/tools ${{ github.event.inputs.buffer }}

--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -44,3 +44,18 @@ bafkzcibcaapn... at 2024-05-28T07:12:45.567Z
 bafkzcibcaapb... at 2024-05-28T07:48:21.420Z
 bafkzcibcaapi... at 2024-05-28T08:23:59.203Z
 ```
+
+### Stat buffer
+
+Analyse a buffer in the pipeline containing Filecoin piece references.
+
+```sh
+$ npm run stat-buffer bafyreid...
+
+> @w3filecoin/tools@0.0.0 stat-buffer
+> node stat-buffer.js bafyreid...
+
+Number of piece:  4
+Total size of pieces:  17188258048n
+Total aggregate used space:  25786580992n
+```

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "get-aggregate-deals": "node get-aggregate-deals.js",
-    "get-aggregates-pending-deals": "node get-aggregates-pending-deals.js"
+    "get-aggregates-pending-deals": "node get-aggregates-pending-deals.js",
+    "stat-buffer": "node stat-buffer.js"
   },
   "dependencies": {},
   "devDependencies": {

--- a/packages/tools/stat-buffer.js
+++ b/packages/tools/stat-buffer.js
@@ -1,0 +1,62 @@
+import { Aggregate, Piece, NODE_SIZE, Index } from '@web3-storage/data-segment'
+import { parseLink } from '@ucanto/server'
+import { createClient as createBufferStoreClient } from '@w3filecoin/core/src/store/aggregator-buffer-store.js'
+
+const AWS_REGION = 'us-west-2'
+const config = {
+  maxAggregateSize: 2**35,
+}
+
+const bufferCidString = process.argv[2]
+if (!bufferCidString) {
+  throw new Error('no buffer CID string was provided')
+}
+
+const bufferStore = createBufferStoreClient({
+  region: AWS_REGION
+}, {
+  name: 'prod-w3filecoin-aggregator-buffer-store-0'
+})
+
+const bufferCid = parseLink(bufferCidString)
+
+// @ts-expect-error CID multiple versions can exist
+const buffer = await bufferStore.get(bufferCid)
+if (buffer.error) {
+  throw new Error(`Error getting buffer: ${buffer.error.message}`)
+}
+
+const bufferedPieces = buffer.ok.buffer.pieces
+const bufferUtilizationSize = bufferedPieces.reduce((total, p) => {
+  const piece = Piece.fromLink(p.piece)
+  total += piece.size
+  return total
+}, 0n)
+
+console.log('Number of piece:', bufferedPieces.length)
+console.log('Total size of pieces:', bufferUtilizationSize)
+
+// Create builder with maximum size and try to fill it up
+const builder = Aggregate.createBuilder({
+  size: Aggregate.Size.from(config.maxAggregateSize),
+})
+
+// add pieces to an aggregate until there is no more space, or no more pieces
+const addedBufferedPieces = []
+const remainingBufferedPieces = []
+
+for (const bufferedPiece of bufferedPieces) {
+  const p = Piece.fromLink(bufferedPiece.piece)
+  if (builder.estimate(p).error) {
+    remainingBufferedPieces.push(bufferedPiece)
+    continue
+  }
+  builder.write(p)
+  addedBufferedPieces.push(bufferedPiece)
+}
+
+const totalUsedSpace =
+  builder.offset * BigInt(NODE_SIZE) +
+  BigInt(builder.limit) * BigInt(Index.EntrySize)
+
+console.log('Total aggregate used space:', totalUsedSpace)


### PR DESCRIPTION
Adds stat command to tools and a github action to run on github UI. This enables us to diagnose incidents related to Buffers. For instance, if a buffer is too big that is causing huge delays on processing due to high number of pieces